### PR TITLE
Implements M1.2c planning flow

### DIFF
--- a/apps/backend/app/agents/lc/schemas.py
+++ b/apps/backend/app/agents/lc/schemas.py
@@ -1,34 +1,106 @@
 from __future__ import annotations
-from typing import List, Dict
-from pydantic import BaseModel, Field, field_validator
+from typing import List, Dict, Literal
+from pydantic import BaseModel, Field, field_validator, ConfigDict
+import json
+
+MAX_NOTES, MAX_TASKS_PER_STORY = 8, 10
+
+STACK_MAP = {"node.js":"node", "nodejs":"node", "reactjs":"react", "sqlite3":"sqlite"}
+
+def _strip(s: str) -> str:
+    return s.strip() if isinstance(s, str) else s
+
+class LLMModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")  # drop unknown keys silently
 
 # Worker outputs (drafts). We'll convert to final domain models in the PM orchestrator.
 
-class ProductVisionDraft(BaseModel):
+class ProductVisionDraft(LLMModel):
     goals: List[str] = Field(default_factory=list)
     personas: List[str] = Field(default_factory=list)
     features: List[str] = Field(default_factory=list)
 
-class TechnicalSolutionDraft(BaseModel):
-    stack: List[str] = Field(default_factory=list)         # e.g., ["node","vite","react","sqlite"]
+class TechnicalSolutionDraft(LLMModel):
+    stack: List[str] = Field(default_factory=list)
     modules: List[str] = Field(default_factory=list)
     interfaces: Dict[str, str] = Field(default_factory=dict)
     decisions: List[str] = Field(default_factory=list)
+    @field_validator("stack", "modules", "decisions")
+    @classmethod
+    def _trim_list(cls, v):
+        if not isinstance(v, list): return []
+        return [str(x).strip() for x in v if str(x).strip()]
+    @field_validator("stack")
+    @classmethod
+    def _norm_stack(cls, v):
+        cleaned = []
+        for x in v:
+            k = str(x).strip().lower()
+            # keep only token before common separators
+            for sep in (" - ", "—", ":", "|", "("):
+                if sep in k:
+                    k = k.split(sep, 1)[0].strip()
+                    break
+            cleaned.append(STACK_MAP.get(k, k))
+        return cleaned
+    @field_validator("interfaces", mode="before")
+    @classmethod
+    def _coerce_interfaces(cls, v):
+        # dict as-is
+        if isinstance(v, dict):
+            return {str(k).strip(): str(val).strip() for k, val in v.items()}
 
-class EpicDraft(BaseModel):
+        # try parse JSON string
+        if isinstance(v, str):
+            s = v.strip()
+            if s.startswith("{") and s.endswith("}"):
+                try:
+                    obj = json.loads(s)
+                    if isinstance(obj, dict):
+                        return {str(k).strip(): str(val).strip() for k, val in obj.items()}
+                except Exception:
+                    pass
+            # "K:V" or "K:V\nK2:V2" fallback
+            out = {}
+            lines = [x for x in s.splitlines() if x.strip()]
+            for line in lines:
+                if ":" in line:
+                    k, val = line.split(":", 1)
+                    out[k.strip()] = val.strip()
+            return out
+
+        # list of "K:V"
+        if isinstance(v, list):
+            out = {}
+            for item in v:
+                s = str(item)
+                if ":" in s:
+                    k, val = s.split(":", 1)
+                    out[k.strip()] = val.strip()
+            return out
+
+        return {}
+
+class EpicDraft(LLMModel):
     title: str
     description: str = ""
+    @field_validator("title", "description")
+    @classmethod
+    def _trim(cls, v): return _strip(v)
 
-class StoryDraft(BaseModel):
-    epic_title: str               # map to epic_id later
+class StoryDraft(LLMModel):
+    epic_title: str
     title: str
     description: str = ""
+    @field_validator("epic_title", "title", "description")
+    @classmethod
+    def _trim(cls, v): return _strip(v)
 
-class RAPlanDraft(BaseModel):
+class RAPlanDraft(LLMModel):
     epics: List[EpicDraft] = Field(default_factory=list)
     stories: List[StoryDraft] = Field(default_factory=list)
 
-class QASpec(BaseModel):
+class QASpec(LLMModel):
     gherkin: List[str] = Field(default_factory=list)
     unit_tests: List[str] = Field(default_factory=list)
 
@@ -51,3 +123,61 @@ class QASpec(BaseModel):
             return [str(x).strip() for x in list(v) if str(x).strip()]
         except Exception:
             return [str(v)]
+
+class DesignNoteDraft(LLMModel):
+    title: str
+    kind: Literal["overview","api","frontend","repo","quality","risk","other"]
+    body_md: str
+    tags: List[str] = Field(default_factory=list)
+    related_epic_titles: List[str] = Field(default_factory=list)
+    related_story_titles: List[str] = Field(default_factory=list)
+    @field_validator("tags", "related_epic_titles", "related_story_titles")
+    @classmethod
+    def _clean_list(cls, v: List[str]) -> List[str]:
+        seen, out = set(), []
+        for x in v or []:
+            k = x.strip()
+            if not k or k.lower() in seen: 
+                continue
+            seen.add(k.lower())
+            out.append(k)
+        return out
+
+class TaskDraft(LLMModel):
+    story_title: str
+    items: List[str] = Field(default_factory=list)
+
+    @field_validator("items", mode="before")
+    @classmethod
+    def _coerce_items(cls, v):
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return [str(x).strip() for x in v if str(x).strip()]
+        if isinstance(v, str):
+            parts = [p.strip(" -*\n\r\t") for p in v.split("\n") if p.strip()]
+            return parts or [v.strip()]
+        return [str(v).strip()]
+
+    @field_validator("items")
+    @classmethod
+    def _cap_items(cls, v):
+        return (v or [])[:MAX_TASKS_PER_STORY]
+
+class TechWritingBundleDraft(LLMModel):
+    notes: List[DesignNoteDraft] = Field(default_factory=list)
+    tasks: List[TaskDraft] = Field(default_factory=list)
+
+    @field_validator("notes", "tasks", mode="before")
+    @classmethod
+    def _ensure_list(cls, v):
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return v
+        return [v]  # coerce single object → list
+
+    @field_validator("notes")
+    @classmethod
+    def _cap_notes(cls, v):
+        return (v or [])[:MAX_NOTES]

--- a/apps/backend/app/agents/meta/product_manager_llm.py
+++ b/apps/backend/app/agents/meta/product_manager_llm.py
@@ -1,27 +1,100 @@
 from __future__ import annotations
 import hashlib
 from typing import Dict, List
-
-from langchain_core.runnables import RunnableParallel
+from types import SimpleNamespace
 
 from app.agents.lc.model_factory import make_chat_model
 from app.agents.planning import vision_lc as VISION
 from app.agents.planning import architect_lc as ARCH
 from app.agents.planning import requirements_analyst_lc as RA
 from app.agents.planning import qa_planner_lc as QA
+from app.agents.planning import tech_writer_lc as TW
+
+from langchain_core.runnables import RunnableConfig
 
 from app.core.models import (
-    ProductVision, TechnicalSolution, Epic, Story, AcceptanceCriteria, PlanBundle
+    ProductVision, TechnicalSolution, Epic, Story, AcceptanceCriteria, PlanBundle, DesignNote, Task
 )
+
+RETRY_ATTEMPTS = 2
+
+def _try_invoke(chain, inp):
+    err = None
+    for _ in range(RETRY_ATTEMPTS):
+        try:
+            return chain.invoke(inp)
+        except Exception as e:
+            err = e
+            # tighten: add a small “repair” hint to the input for the model
+            if isinstance(inp, dict):
+                inp = {**inp, "repair_hint": f"Previous output failed schema: {type(e).__name__}. Ensure valid JSON per schema."}
+    if err:
+        raise err
 
 REQUIRED_STACK = {"node", "vite", "react", "sqlite"}
 
+def _synthesize_tasks_for_story(story: Story, solution: TechnicalSolution) -> list[str]:
+    title = (story.title or "").lower()
+    desc  = (story.description or "").lower()
+    has_endpoint = "endpoint" in title or "/health" in title or "/health" in desc
+    items = []
+
+    if has_endpoint:
+        items = [
+            "Scaffold Express app and router",
+            "Add GET /health controller",
+            "Wire HealthService.getHealthStatus()",
+            "Implement HealthRepository.checkDatabaseConnection()",
+            "Return {status:'ok'} with 200 on success; 503 on failure",
+            "Register route in server and add OpenAPI doc",
+            "Add Jest tests for controller and service",
+        ]
+    elif "repository" in title:
+        items = [
+            "Create HealthRepository module",
+            "Implement checkDatabaseConnection() using sqlite client",
+            "Add error handling and timeouts",
+            "Export repository factory for DI",
+            "Write Jest unit tests with connection mock",
+        ]
+    elif "service" in title:
+        items = [
+            "Create HealthService module",
+            "Implement getHealthStatus() aggregating repository result",
+            "Map status to {UP/DOWN} JSON",
+            "Handle exceptions from repository",
+            "Write Jest unit tests for happy/error paths",
+        ]
+    elif "frontend" in title or "component" in title:
+        items = [
+            "Create HealthComponent in React",
+            "Create ApiClient.fetchHealthStatus()",
+            "Render status with loading and error states",
+            "Add basic styles and accessibility",
+            "Write component tests (React Testing Library)",
+        ]
+    else:
+        items = [
+            "Define detailed requirements",
+            "Implement core logic",
+            "Add error handling and logging",
+            "Write unit tests and docs",
+        ]
+    return items[:8]
+
 def _normalize_stack(stack_items):
-    norm_map = {"node.js": "node", "nodejs": "node", "node js": "node",
-                "reactjs": "react", "sqlite3": "sqlite"}
+    norm_map = {
+        "node.js":"node","nodejs":"node","node js":"node",
+        "reactjs":"react","sqlite3":"sqlite",
+        "express.js":"express"
+        }
     out = set()
     for s in (stack_items or []):
         k = str(s).strip().lower()
+        for sep in (" - ", "—", ":", "|", "("):
+            if sep in k:
+                k = k.split(sep, 1)[0].strip()
+                break
         out.add(norm_map.get(k, k))
     return out
 
@@ -44,12 +117,6 @@ def _order_epics_and_stories(epics: List[Epic], stories: List[Story]) -> tuple[L
             new_stories.append(Story(**{**s.model_dump(), "priority_rank": j}))
     return epics, new_stories
 
-def _validate_guardrails(ts: TechnicalSolution):
-    stack = {x.lower() for x in (ts.stack or [])}
-    missing = REQUIRED_STACK - stack
-    if missing:
-        raise ValueError(f"Solution violates guardrails; missing stack items: {sorted(missing)}")
-
 def _guardrail_warnings(ts: TechnicalSolution) -> list[str]:
     stack = _normalize_stack(ts.stack)
     missing = sorted(REQUIRED_STACK - stack)
@@ -64,6 +131,8 @@ class ProductManagerLLM:
         self.arch_chain   = ARCH.make_chain(self.llm)
         self.ra_chain     = RA.make_chain(self.llm)
         self.qa_chain     = QA.make_chain(self.llm)
+        self.tw_notes_chain = TW.make_notes_chain(self.llm)
+        self.tw_tasks_chain = TW.make_tasks_chain(self.llm)
 
     def plan(self, requirement: Dict) -> PlanBundle:
         # 1) Vision
@@ -114,19 +183,94 @@ class ProductManagerLLM:
         stories: List[Story] = []
         for sd in ra.stories:
             epic_id = epic_map.get(sd.epic_title.strip().lower())
-            if not epic_id:
-                # fallback: if missing, attach to first epic
-                epic_id = epics[0].id if epics else _gen_id("E", requirement["id"] + ":default")
-                if not epics:
-                    epics.append(Epic(id=epic_id, title="Default Epic", description="", priority_rank=1))
+        if not epic_id:
+            epic_id = epics[0].id if epics else _gen_id("E", requirement["id"] + ":default")
+        if not epics:
+            epics.append(Epic(id=epic_id, title="Default Epic", description="", priority_rank=1))
             sid = _gen_id("S", requirement["id"] + ":" + sd.title)
             stories.append(Story(
                 id=sid, epic_id=epic_id, title=sd.title, description=sd.description,
                 priority_rank=1, acceptance=[], tests=[]
             ))
+        
+        if not stories:
+            # synthesize one story per epic to keep plan usable
+            for e in epics:
+                sid = _gen_id("S", requirement["id"] + ":" + e.title)
+                stories.append(Story(
+                    id=sid,
+                    epic_id=e.id,
+                    title=f"Deliver {e.title}",
+                    description=e.description or "",
+                    priority_rank=1,
+                    acceptance=[],
+                    tests=[],
+                ))
 
         # 4) PM ordering (deterministic ranks)
         epics, stories = _order_epics_and_stories(epics, stories)
+
+        # --- Tech Writer: Design Notes ---
+        notes_bundle = _try_invoke(self.tw_notes_chain, {
+            "features": ", ".join(vision.features),
+            "stack": ", ".join(solution.stack),
+            "modules": ", ".join(solution.modules),
+            "interfaces": ", ".join(f"{k}:{v}" for k,v in (solution.interfaces or {}).items()),
+            "decisions": ", ".join(solution.decisions or []),
+            "epic_titles": ", ".join(e.title for e in epics[:6]),
+            "story_titles": ", ".join(s.title for s in stories[:12]),
+        })
+        notes = getattr(notes_bundle, "notes", []) or []
+
+        # --- Tech Writer: Tasks per story (map over stories) ---
+        task_inputs = []
+        epic_title_by_id = {e.id: e.title for e in epics}
+        for s in stories:
+            gherkin_list = [ac.gherkin for ac in (s.acceptance or []) if ac.gherkin]
+            task_inputs.append({
+                "story_title": s.title,
+                "story_description": s.description,
+                "epic_title": epic_title_by_id.get(s.epic_id, ""),
+                "interfaces": ", ".join(f"{k}:{v}" for k, v in (solution.interfaces or {}).items()),
+                "gherkin": "\n".join(gherkin_list) if gherkin_list else "",
+            })
+
+        # A strict batch with second-chance retry per item
+        task_drafts = []
+        for inp in task_inputs:
+            task_drafts.append(_try_invoke(self.tw_tasks_chain, inp))
+
+        # Map titles -> ids
+        epic_id_by_title = {e.title.strip().lower(): e.id for e in epics}
+        story_id_by_title = {s.title.strip().lower(): s.id for s in stories}
+
+        # Build DesignNotes
+        design_notes: list[DesignNote] = []
+        for nd in notes:
+            dn_id = _gen_id("DN", requirement["id"] + ":" + nd.title)
+            design_notes.append(DesignNote(
+                id=dn_id,
+                title=nd.title,
+                kind=nd.kind,
+                body_md=nd.body_md,
+                tags=getattr(nd, "tags", []),
+                related_epic_ids=[epic_id_by_title.get(t.strip().lower()) for t in getattr(nd,"related_epic_titles",[]) if epic_id_by_title.get(t.strip().lower())],
+                related_story_ids=[story_id_by_title.get(t.strip().lower()) for t in getattr(nd,"related_story_titles",[]) if story_id_by_title.get(t.strip().lower())],
+            ))
+
+        # Build Tasks (STRICT: from LLM only; no defaults)
+        tasks_by_story: dict[str, list[Task]] = {s.id: [] for s in stories}
+        for td in task_drafts:
+            title_key = getattr(td, "story_title", "").strip().lower()
+            sid = story_id_by_title.get(title_key)
+            if not sid:
+                continue
+            for i, title in enumerate(td.items or [], start=1):
+                tid = _gen_id("T", requirement["id"] + ":" + sid + f":{i}:{title}")
+                tasks_by_story[sid].append(Task(id=tid, story_id=sid, title=title, order=i, status="todo"))
+
+        for s in stories:
+            s.tasks = tasks_by_story.get(s.id, [])
 
         # 5) QA per story (batch)
         inputs = [{
@@ -135,19 +279,26 @@ class ProductManagerLLM:
             "epic_title": next((e.title for e in epics if e.id == s.epic_id), ""),
             "interfaces": ", ".join(f"{k}:{v}" for k, v in (solution.interfaces or {}).items()),
         } for s in stories]
-        qa_results = self.qa_chain.batch(inputs, max_concurrency=4)
+       
+        try:
+            qa_results = self.qa_chain.batch(inputs, max_concurrency=4) or [None] * len(stories)
+        except Exception as e:
+            # Never fail planning because QA parsing failed
+            solution.decisions = (solution.decisions or []) + [f"QA parse failed ({type(e).__name__}); continuing."]
+            qa_results = [None] * len(stories)
 
         # attach AC/tests
         for s, qa in zip(stories, qa_results):
-            gherkins = qa.gherkin or [
+            gherkins = getattr(qa, "gherkin", None) or [
                 "Given the system is running\nWhen the user performs the main action\nThen an observable successful result is returned"
             ]
             s.acceptance = [AcceptanceCriteria(story_id=s.id, gherkin=g) for g in gherkins]
-            s.tests = qa.unit_tests or ["unit tests cover happy path and validation"]
+            s.tests = getattr(qa, "unit_tests", None) or ["unit tests cover happy path and validation"]
 
         return PlanBundle(
             product_vision=vision,
             technical_solution=solution,
             epics=epics,
             stories=stories,
+            design_notes=design_notes,
         )

--- a/apps/backend/app/agents/planning/tech_writer_lc.py
+++ b/apps/backend/app/agents/planning/tech_writer_lc.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from app.agents.lc.schemas import DesignNoteDraft, TechWritingBundleDraft, TaskDraft
+
+# --- Design Notes ---
+
+def make_notes_chain(llm):
+    """
+    Returns a chain that emits ONLY design notes (no tasks).
+    Output is parsed as TechWritingBundleDraft but we only use .notes.
+    """
+    prompt = ChatPromptTemplate.from_messages([
+        ("system",
+        "You are a senior technical writer. Create concise design notes to guide implementation.\n"
+        "STRICT RULES:\n"
+        "- Output MUST be valid JSON for the Pydantic schema TechWritingBundleDraft(notes only).\n"
+        "- Fill `notes` with 2–5 items. Do NOT include tasks here.\n"
+        "- Each note MUST have: title, kind in {{overview,api,frontend,repo,quality,risk,other}}, body_md.\n"
+        "- Use related_epic_titles and related_story_titles to link by EXACT TITLES from the provided lists.\n"),
+        ("human",
+         "Context:\n"
+         "- Features: {features}\n"
+         "- Stack: {stack}\n"
+         "- Modules: {modules}\n"
+         "- Interfaces: {interfaces}\n"
+         "- Decisions: {decisions}\n"
+         "- Epics: {epic_titles}\n"
+         "- Stories: {story_titles}\n"
+         "Return JSON ONLY."),
+    ])
+    # Force the shape via structured output
+    return prompt | llm.with_structured_output(TechWritingBundleDraft)
+
+# --- Per-story Tasks ---
+
+def make_tasks_chain(llm):
+    """
+    Returns a chain that, given a single story input, emits TaskDraft for THAT story.
+    We will batch() over stories at the orchestrator.
+    """
+    prompt = ChatPromptTemplate.from_messages([
+        ("system",
+         "You are a pragmatic tech writer. Produce implementable, granular tasks that an engineer can execute.\n"
+         "STRICT RULES:\n"
+         "- Output MUST be valid JSON for the Pydantic schema TaskDraft.\n"
+         "- story_title MUST equal the provided story_title EXACTLY.\n"
+         "- items MUST be 5–10 atomic steps (no vague items like 'do the thing').\n"
+         "- Prefer verbs like: scaffold, implement, wire, validate, handle error, write unit test.\n"
+         "- Align tasks with acceptance criteria & interfaces.\n"),
+        ("human",
+         "Story:\n"
+         "- story_title: {story_title}\n"
+         "- description: {story_description}\n"
+         "- epic_title: {epic_title}\n"
+         "- interfaces: {interfaces}\n"
+         "- acceptance_criteria (Gherkin snippets):\n{gherkin}\n"
+         "Return JSON ONLY."),
+    ])
+    return prompt | llm.with_structured_output(TaskDraft)

--- a/apps/backend/app/api/plan.py
+++ b/apps/backend/app/api/plan.py
@@ -5,19 +5,34 @@ from app.core.models import PlanBundle
 from app.storage.db import get_db
 from app.core.planner import plan_run, read_plan
 
+import os, logging
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 @router.post("/runs/{run_id}/plan", response_model=PlanBundle)
-def post_plan(run_id: str, db: Session = Depends(get_db)):
+def post_plan(run_id: str, force: bool = False, db: Session = Depends(get_db)):
     try:
+        if not force:
+            # try to read; if missing, create
+            try:
+                return read_plan(db, run_id)
+            except ValueError as e:
+                if "plan not found" in str(e).lower():
+                    return plan_run(db, run_id)
+                raise
+        # force => always (re)plan
         return plan_run(db, run_id)
+
     except ValueError as e:
-        # we use ValueError only for "requirement not found"
-        if "requirement not found" in str(e).lower():
-            raise HTTPException(status_code=404, detail=str(e))
-        raise HTTPException(status_code=400, detail=str(e))
+        msg = str(e)
+        if "requirement not found" in msg.lower() or "plan not found" in msg.lower():
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
     except Exception as e:
-        # unexpected planner/LLM errors
+        logger.exception("planning failed")
+        if os.getenv("DEBUG_PLANNING") == "1":
+            raise HTTPException(status_code=500, detail=f"planning failed: {e}")
         raise HTTPException(status_code=500, detail="planning failed")
 
 @router.get("/runs/{run_id}/plan", response_model=PlanBundle)

--- a/apps/backend/app/core/models.py
+++ b/apps/backend/app/core/models.py
@@ -10,7 +10,7 @@ class Requirement(BaseModel):
     description: str
     constraints: list[str] = []
     priority: Literal["Must", "Should", "Could"] = "Should"
-    non_functionals: list[str] = []
+    non_functionals: list[str] = Field(default_factory=list)
 
 
 class AcceptanceCriteria(BaseModel):
@@ -21,34 +21,32 @@ class Task(BaseModel):
     id: str
     story_id: str
     title: str
-    definition_of_done: list[str]
+    order: int = 1
+    status: Literal["todo", "doing", "done"] = "todo"  # optional; will be filtered if ORM lacks this column
 
 
 class DesignNote(BaseModel):
-    id: Optional[str] = None
-    scope: str
-    decisions: list[str]
-    interfaces: dict[str, str]
+    id: str
+    title: str
+    kind: Literal["overview", "api", "frontend", "repo", "quality", "risk", "other"]  # overview|api|frontend|repo|quality|risk|other
+    body_md: str
+    tags: list[str] = Field(default_factory=list)
+    related_epic_ids: list[str] = Field(default_factory=list)
+    related_story_ids: list[str] = Field(default_factory=list)
 
-
-class BacklogBundle(BaseModel):
-    stories: list[Story]
-    tasks: list[Task]
-    acceptance: list[AcceptanceCriteria]
-    design: Optional[DesignNote] = None
 
 class ProductVision(BaseModel):
     id: str
-    goals: list[str]
-    personas: list[str] = []
-    features: list[str]
+    goals: list[str] = Field(default_factory=list)
+    personas: list[str] = Field(default_factory=list)
+    features: list[str] = Field(default_factory=list)
 
 class TechnicalSolution(BaseModel):
     id: str
-    stack: list[str] # e.g., ["node", "vite", "react", "sqlite"]
-    modules: list[str]
-    interfaces: dict[str, str]
-    decisions: list[str]
+    stack: list[str] = Field(default_factory=list)# e.g., ["node", "vite", "react", "sqlite"]
+    modules: list[str] = Field(default_factory=list)
+    interfaces: dict[str, str] = Field(default_factory=dict)
+    decisions: list[str] = Field(default_factory=list)
 
 
 class Epic(BaseModel):
@@ -63,23 +61,25 @@ class Story(BaseModel): # extend exiting Story if already defined; else define
     title: str
     description: str = ""
     priority_rank: int = Field(ge=1, description="1 = highest priority")
-    acceptance: list["AcceptanceCriteria"] = [] # forward ref ok
-    tests: list[str] = []
+    acceptance: list["AcceptanceCriteria"] = Field(default_factory=list)
+    tests: list[str] = Field(default_factory=list)
+    tasks: list[Task] = Field(default_factory=list)
 
 class PlanBundle(BaseModel):
     product_vision: ProductVision
     technical_solution: TechnicalSolution
-    epics: list[Epic]
-    stories: list[Story]
+    epics: list[Epic] = Field(default_factory=list)
+    stories: list[Story] = Field(default_factory=list)
+    design_notes: list[DesignNote] = Field(default_factory=list)
 
 # ====== Run / Manifest ======
 class RunCreate(BaseModel):
     title: str = Field(..., description="Short label for the run")
     requirement_title: str
     requirement_description: str
-    constraints: list[str] = []
+    constraints: list[str] = Field(default_factory=list)
     priority: Literal["Must", "Should", "Could"] = "Should"
-    non_functionals: list[str] = []
+    non_functionals: list[str] = Field(default_factory=list)
 
 
 class RunManifest(BaseModel):

--- a/apps/backend/app/core/planner.py
+++ b/apps/backend/app/core/planner.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
-import uuid
+
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
-from app.core.models import PlanBundle, ProductVision, TechnicalSolution, Epic, Story, AcceptanceCriteria
+from app.core.models import (
+    PlanBundle, ProductVision, TechnicalSolution, Epic, Story,
+    AcceptanceCriteria, Requirement, Task, DesignNote
+)
+
 from app.storage.models import (
     RequirementORM, ProductVisionORM, TechnicalSolutionORM,
-    EpicORM, StoryORM, AcceptanceORM
+    EpicORM, StoryORM, AcceptanceORM, TaskORM, DesignNoteORM
 )
 from app.agents.meta.product_manager_llm import ProductManagerLLM
 
 pm = ProductManagerLLM()
+
+
 
 def _persist_plan(db: Session, run_id: str, requirement: RequirementORM, bundle: PlanBundle) -> None:
     # product vision & technical solution as JSON blobs
@@ -30,11 +37,91 @@ def _persist_plan(db: Session, run_id: str, requirement: RequirementORM, bundle:
             epic_id=s.epic_id, title=s.title, description=s.description,
             priority_rank=s.priority_rank, tests=s.tests
         ))
-        # clear+write acceptance entries (simple approach: upsert by id)
+        # clear then re-write acceptance entries
+        db.query(AcceptanceORM).filter_by(run_id=run_id, story_id=s.id).delete(synchronize_session=False)
         for i, ac in enumerate(s.acceptance, start=1):
             db.merge(AcceptanceORM(
                 id=f"AC-{s.id}-{i}", run_id=run_id, story_id=s.id, gherkin=ac.gherkin
             ))
+
+    def _columns(model) -> set[str]:
+        try:
+            return {c.key for c in sa_inspect(model).columns}
+        except Exception:
+            return set(getattr(model, "__table__").columns.keys())
+
+    task_cols = _columns(TaskORM)
+    dn_cols = _columns(DesignNoteORM)
+
+    # Tasks (clear then write)
+    db.query(TaskORM).filter_by(run_id=run_id).delete(synchronize_session=False)
+    for s in bundle.stories:
+        for t in s.tasks:
+            kwargs = {
+                "id": t.id,
+                "run_id": run_id,
+                "story_id": s.id,
+                "title": t.title,
+            }
+            if "order" in task_cols:
+                kwargs["order"] = t.order
+            if "status" in task_cols:
+                kwargs["status"] = t.status
+            db.merge(TaskORM(**kwargs))
+
+    # Design Notes (clear then write)
+    db.query(DesignNoteORM).filter_by(run_id=run_id).delete(synchronize_session=False)
+
+    dn_cols = _columns(DesignNoteORM)
+
+    def _as_data_blob(dn: DesignNote) -> dict:
+        return {
+            "title": dn.title,
+            "kind": dn.kind,
+            "body_md": dn.body_md,
+            "tags": dn.tags,
+            "related_epic_ids": dn.related_epic_ids,
+            "related_story_ids": dn.related_story_ids,
+        }
+
+    for dn in bundle.design_notes:
+        kwargs = {
+            "id": dn.id,
+            "run_id": run_id,
+        }
+
+        # Required by your current schema
+        if "scope" in dn_cols:
+            kwargs["scope"] = "run"  # run-scoped note
+
+        # Prefer column-by-column if present
+        if "title" in dn_cols:
+            kwargs["title"] = dn.title
+        if "body_md" in dn_cols:
+            kwargs["body_md"] = dn.body_md
+        if "kind" in dn_cols:
+            kwargs["kind"] = dn.kind
+        if "tags" in dn_cols:
+            kwargs["tags"] = dn.tags
+        if "related_epic_ids" in dn_cols:
+            kwargs["related_epic_ids"] = dn.related_epic_ids
+        if "related_story_ids" in dn_cols:
+            kwargs["related_story_ids"] = dn.related_story_ids
+
+         # If your ORM stores solution context on design_notes, populate it
+        if "decisions" in dn_cols:
+            kwargs["decisions"] = bundle.technical_solution.decisions or []
+        if "interfaces" in dn_cols:
+            kwargs["interfaces"] = bundle.technical_solution.interfaces or {}
+
+        # If this table uses a single JSON blob (e.g. 'data') and
+        # does NOT have the first-class columns above, store the note there.
+        if "data" in dn_cols and not any(
+            c in dn_cols for c in ("title","body_md","kind","tags","related_epic_ids","related_story_ids")
+        ):
+            kwargs["data"] = _as_data_blob(dn)
+
+        db.merge(DesignNoteORM(**kwargs))
 
     db.commit()
 
@@ -64,27 +151,112 @@ def read_plan(db: Session, run_id: str) -> PlanBundle:
     if not pv or not ts:
         raise ValueError("plan not found for run")
 
-    epics_orm = db.query(EpicORM).filter_by(run_id=run_id).order_by(EpicORM.priority_rank.asc()).all()
-    stories_orm = db.query(StoryORM).filter_by(run_id=run_id).order_by(StoryORM.epic_id, StoryORM.priority_rank.asc()).all()
+    # ---- Epics & Stories
+    epics_orm = (
+        db.query(EpicORM)
+        .filter_by(run_id=run_id)
+        .order_by(EpicORM.priority_rank.asc())
+        .all()
+    )
+    stories_orm = (
+        db.query(StoryORM)
+        .filter_by(run_id=run_id)
+        .order_by(StoryORM.epic_id, StoryORM.priority_rank.asc())
+        .all()
+    )
 
-    # map acceptance by story
+    # Acceptance by story
     ac_rows = db.query(AcceptanceORM).filter_by(run_id=run_id).all()
-    ac_by_story = {}
+    ac_by_story: dict[str, list[AcceptanceCriteria]] = {}
     for r in ac_rows:
-        ac_by_story.setdefault(r.story_id, []).append(AcceptanceCriteria(story_id=r.story_id, gherkin=r.gherkin))
+        ac_by_story.setdefault(r.story_id, []).append(
+            AcceptanceCriteria(story_id=r.story_id, gherkin=r.gherkin)
+        )
 
-    epics = [Epic(id=e.id, title=e.title, description=e.description, priority_rank=e.priority_rank) for e in epics_orm]
+    epics = [
+        Epic(
+            id=e.id,
+            title=e.title,
+            description=e.description,
+            priority_rank=e.priority_rank,
+        )
+        for e in epics_orm
+    ]
+
     stories = [
         Story(
-            id=s.id, epic_id=s.epic_id, title=s.title, description=s.description,
-            priority_rank=s.priority_rank or 1, acceptance=ac_by_story.get(s.id, []), tests=s.tests or []
+            id=s.id,
+            epic_id=s.epic_id,
+            title=s.title,
+            description=s.description,
+            priority_rank=s.priority_rank or 1,
+            acceptance=ac_by_story.get(s.id, []),
+            tests=s.tests or [],
         )
         for s in stories_orm
     ]
+
+    # ---- Tasks by story
+    task_rows = db.query(TaskORM).filter_by(run_id=run_id).all()
+    tasks_by_story: dict[str, list[Task]] = {}
+    for tr in task_rows:
+        tasks_by_story.setdefault(tr.story_id, []).append(
+            Task(
+                id=tr.id,
+                story_id=tr.story_id,
+                title=tr.title,
+                order=getattr(tr, "order", 1),
+                status=getattr(tr, "status", "todo"),
+            )
+        )
+    for s in stories:
+        s.tasks = sorted(tasks_by_story.get(s.id, []), key=lambda t: t.order)
+
+    # ---- Design notes (handle both columnized and JSON-blob tables)
+    dn_cols = {c.key for c in sa_inspect(DesignNoteORM).columns}
+    dn_rows = db.query(DesignNoteORM).filter_by(run_id=run_id).all()
+    design_notes: list[DesignNote] = []
+
+    def _from_data_blob(r) -> DesignNote:
+        data = getattr(r, "data", {}) or {}
+        return DesignNote(
+            id=r.id,
+            title=data.get("title", "Design note"),
+            kind=data.get("kind", "other"),
+            body_md=data.get("body_md", ""),
+            tags=data.get("tags", []),
+            related_epic_ids=data.get("related_epic_ids", []),
+            related_story_ids=data.get("related_story_ids", []),
+        )
+
+    for r in dn_rows:
+        if "data" in dn_cols and getattr(r, "data", None):
+            note = _from_data_blob(r)
+        else:
+            # Column-by-column with safe defaults
+            title = getattr(r, "title", None) or "Design note"
+            kind = getattr(r, "kind", None) or "other"
+            body_md = getattr(r, "body_md", None) or ""
+            tags = getattr(r, "tags", None) or []
+            related_epic_ids = getattr(r, "related_epic_ids", None) or []
+            related_story_ids = getattr(r, "related_story_ids", None) or []
+            note = DesignNote(
+                id=r.id,
+                title=title,
+                kind=kind,
+                body_md=body_md,
+                tags=tags,
+                related_epic_ids=related_epic_ids,
+                related_story_ids=related_story_ids,
+            )
+        design_notes.append(note)
+
+    design_notes.sort(key=lambda dn: (dn.kind, dn.title.lower()))
 
     return PlanBundle(
         product_vision=ProductVision(**pv.data),
         technical_solution=TechnicalSolution(**ts.data),
         epics=epics,
         stories=stories,
+        design_notes=design_notes,
     )


### PR DESCRIPTION
Implements M1.2c planning flow

Meta-agent (Product Manager) orchestrates Vision, Architect, Requirements Analyst, QA, Tech Writer

Deterministic IDs/ranks; guardrail warnings added to decisions

Persists ProductVision, TechnicalSolution, Epics, Stories (+AC/tests), Tasks, Design Notes

read_plan tolerant of design_notes schema (columns or JSON blob)

API

POST /runs/{id}/plan?force=true regenerate & persist

GET /runs/{id}/plan fetch persisted plan