### PR TITLE
Fix duplicate DELETE request when removing runs

### DIFF
--- a/apps/frontend/src/pages/PlanManageRun.tsx
+++ b/apps/frontend/src/pages/PlanManageRun.tsx
@@ -103,7 +103,8 @@ export default function PlanManageRun() {
     if (!ok) return;
     setBusy(true);
     try {
-      const res = await deleteRun(selectedId);
+      const id = selectedId;
+      const res = await deleteRun(id);
       // show counts if backend returned them
       if (res.ok && res.deleted) {
         alert(
@@ -112,10 +113,9 @@ export default function PlanManageRun() {
         );
       }
       // hard refresh list; if current selection disappeared, UI clears accordingly
-      setRuns(rs => rs.filter(r => r.id !== selectedId));
+      setRuns(rs => rs.filter(r => r.id !== id));
       setSelectedId("");
       setDetail(null);
-      await deleteRun(selectedId);
       await refreshRuns(false); // list again from backend
     } finally {
       setBusy(false);


### PR DESCRIPTION
## Summary
- ensure PlanManageRun only issues a single deleteRun request per removal
- update local state cleanup to reference the captured id before refreshing the list

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68f0d613a5388328917b05288ea6067a